### PR TITLE
Changes - to collapse the condition.

### DIFF
--- a/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkUploadBackgroundJobActor.java
+++ b/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkUploadBackgroundJobActor.java
@@ -159,19 +159,21 @@ public class UserBulkUploadBackgroundJobActor extends BaseBulkUploadBackgroundJo
               JsonKey.CREATE);
           return;
         } else {
-          if (StringUtils.isNotBlank(orgId) && StringUtils.isNotBlank(orgExternalId)) {
-            if (!(orgId).equalsIgnoreCase(organisation.getId())) {
-              String message =
-                  MessageFormat.format(
-                      ResponseCode.errorConflictingValues.getErrorMessage(),
-                      JsonKey.ORGANISATION_ID,
-                      orgId,
-                      JsonKey.ORG_EXTERNAL_ID,
-                      orgExternalId);
-              setTaskStatus(
-                  task, ProjectUtil.BulkProcessStatus.FAILED, message, userMap, JsonKey.CREATE);
-              return;
-            }
+          if (StringUtils.isNotBlank(orgId)
+              && StringUtils.isNotBlank(orgExternalId)
+              && !(orgId).equalsIgnoreCase(organisation.getId())) {
+
+            String message =
+                MessageFormat.format(
+                    ResponseCode.errorConflictingValues.getErrorMessage(),
+                    JsonKey.ORGANISATION_ID,
+                    orgId,
+                    JsonKey.ORG_EXTERNAL_ID,
+                    orgExternalId);
+            setTaskStatus(
+                task, ProjectUtil.BulkProcessStatus.FAILED, message, userMap, JsonKey.CREATE);
+            return;
+
           } else {
             if (StringUtils.isNotBlank(orgExternalId)) {
               userMap.put(JsonKey.ORGANISATION_ID, organisation.getId());


### PR DESCRIPTION
Earlier:
if( orgId && externalOrgId not blank){
   if(orgId && derived Org Id from external Id not same){
     then throw error
    }
    return;
 else{
    if(externalid not blank)
      then use orgId from externalId
    else
      then use org Id directly
  }

  Due to this - when orgId & externalId were exactly same, the org id
value was not getting set at all.