### PR TITLE
Issues #SB-0000 fix: some of old org having staus as null and if we a…

### DIFF
--- a/actors/common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/actors/common/src/main/java/org/sunbird/learner/util/Util.java
@@ -142,6 +142,13 @@ public final class Util {
             OrgStatus.RETIRED.getValue()));
     orgStatusTransition.put(
         OrgStatus.RETIRED.getValue(), Arrays.asList(OrgStatus.RETIRED.getValue()));
+    orgStatusTransition.put(
+        null,
+        Arrays.asList(
+            OrgStatus.ACTIVE.getValue(),
+            OrgStatus.INACTIVE.getValue(),
+            OrgStatus.BLOCKED.getValue(),
+            OrgStatus.RETIRED.getValue()));
   }
 
   private static void initializeAuditLogUrl() {


### PR DESCRIPTION
Some of the old org status is null and now user creation is not allowed if org status is either null or inactive . User creation allowed only if status is 1. 
we have separate api to update org status, but there we won't have null conditions, so adding null condition as well.