### PR TITLE
Fixes for the issue.

### DIFF
--- a/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/BaseBulkUploadBackgroundJobActor.java
+++ b/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/BaseBulkUploadBackgroundJobActor.java
@@ -87,7 +87,9 @@ public abstract class BaseBulkUploadBackgroundJobActor extends BaseBulkUploadAct
         bulkUploadProcess.setFailureResult(e.getMessage());
         bulkUploadDao.update(bulkUploadProcess);
         ProjectLogger.log(
-            logMessagePrefix + "Exception occurred with error message = " + e.getMessage(),LoggerEnum.INFO, e);
+            logMessagePrefix + "Exception occurred with error message = " + e.getMessage(),
+            LoggerEnum.INFO,
+            e);
       }
     }
 
@@ -116,11 +118,18 @@ public abstract class BaseBulkUploadBackgroundJobActor extends BaseBulkUploadAct
       sequenceRange.put(Constants.LTE, nextSequence);
       queryMap.put(BulkUploadJsonKey.SEQUENCE_ID, sequenceRange);
       List<BulkUploadProcessTask> tasks = bulkUploadProcessTaskDao.readByPrimaryKeys(queryMap);
-      if(tasks==null) {
-    	  ProjectLogger.log(
-    	            logMessagePrefix + "No bulkUploadProcessTask found for process id: " + bulkUploadProcess.getId() + " and range " + sequence + ":" + nextSequence,LoggerEnum.INFO);
-          sequence = nextSequence;
-    	  continue;
+      if (tasks == null) {
+        ProjectLogger.log(
+            logMessagePrefix
+                + "No bulkUploadProcessTask found for process id: "
+                + bulkUploadProcess.getId()
+                + " and range "
+                + sequence
+                + ":"
+                + nextSequence,
+            LoggerEnum.INFO);
+        sequence = nextSequence;
+        continue;
       }
       function.apply(tasks);
 
@@ -140,7 +149,9 @@ public abstract class BaseBulkUploadBackgroundJobActor extends BaseBulkUploadAct
 
       } catch (IOException e) {
         ProjectLogger.log(
-            logMessagePrefix + "Exception occurred with error message = " + e.getMessage(),LoggerEnum.INFO, e);
+            logMessagePrefix + "Exception occurred with error message = " + e.getMessage(),
+            LoggerEnum.INFO,
+            e);
       }
       performBatchUpdate(tasks);
       sequence = nextSequence;
@@ -171,7 +182,9 @@ public abstract class BaseBulkUploadBackgroundJobActor extends BaseBulkUploadAct
 
     } catch (Exception e) {
       ProjectLogger.log(
-          logMessagePrefix + "Exception occurred with error message = " + e.getMessage(), LoggerEnum.INFO, e);
+          logMessagePrefix + "Exception occurred with error message = " + e.getMessage(),
+          LoggerEnum.INFO,
+          e);
     }
     bulkUploadDao.update(bulkUploadProcess);
   }
@@ -229,7 +242,9 @@ public abstract class BaseBulkUploadBackgroundJobActor extends BaseBulkUploadAct
       file = File.createTempFile(objType, "upload");
     } catch (IOException e) {
       ProjectLogger.log(
-          logMessagePrefix + "Exception occurred with error message = " + e.getMessage(), LoggerEnum.INFO, e);
+          logMessagePrefix + "Exception occurred with error message = " + e.getMessage(),
+          LoggerEnum.INFO,
+          e);
     }
     return file;
   }


### PR DESCRIPTION
Due to boundary condition - when no of records was exactly in multiple
of batch-size, instead of breaking out of the loop, we were querying
cassandra one more time. Which was returning null - if no records found,
same situation was not handled.
Now handling null return value as well as fixing the boundray condition.