### PR TITLE
SC-1253 Enhancing Search API

### DIFF
--- a/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
+++ b/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
@@ -348,7 +348,7 @@ public class SearchHandlerActor extends BaseActor {
 
   /**
    * this method will convert the  Sunbird required fields(source,externalId,userName,provider,loginId,email)
-   * into lower case and encrypt them ass well
+   * into lower case and encrypt them as well
    * @param searchQueryMap
    * @throws Exception
    */

--- a/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
+++ b/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
@@ -86,6 +86,7 @@ public class SearchHandlerActor extends BaseActor {
           filterObjectType = EsType.organisation.getTypeName();
         }
       }
+      lowerAndEncryptORFilterData(searchQueryMap);
       SearchDTO searchDto = Util.createSearchDto(searchQueryMap);
       if (filterObjectType.equalsIgnoreCase(EsType.user.getTypeName())) {
         searchDto.setExcludedFields(Arrays.asList(ProjectUtil.excludes));
@@ -343,5 +344,20 @@ public class SearchHandlerActor extends BaseActor {
     map.put(JsonKey.PARAMS, params);
     map.put(JsonKey.TELEMETRY_EVENT_TYPE, "SEARCH");
     return map;
+  }
+  public void lowerAndEncryptORFilterData(Map<String, Object> searchQueryMap) throws Exception {
+    Map<String,Object>ORFilterMap= (Map<String, Object>) ((Map<String, Object>)(searchQueryMap.get(JsonKey.FILTERS))).get(JsonKey.ES_OR_OPERATION);
+    if(MapUtils.isNotEmpty(ORFilterMap)) {
+      Arrays.asList(
+              ProjectUtil.getConfigValue(JsonKey.SUNBIRD_API_REQUEST_LOWER_CASE_FIELDS).split(","))
+              .stream()
+              .forEach(
+                      field -> {
+                        if (StringUtils.isNotBlank((String) ORFilterMap.get(field))) {
+                          ORFilterMap.put(field, ((String) ORFilterMap.get(field)).toLowerCase());
+                        }
+                      });
+      UserUtility.encryptUserData(ORFilterMap);
+    }
   }
 }

--- a/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
+++ b/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
@@ -86,7 +86,7 @@ public class SearchHandlerActor extends BaseActor {
           filterObjectType = EsType.organisation.getTypeName();
         }
       }
-      lowerAndEncryptORFilterData(searchQueryMap);
+      extractOrFilter(searchQueryMap);
       SearchDTO searchDto = Util.createSearchDto(searchQueryMap);
       if (filterObjectType.equalsIgnoreCase(EsType.user.getTypeName())) {
         searchDto.setExcludedFields(Arrays.asList(ProjectUtil.excludes));
@@ -345,7 +345,14 @@ public class SearchHandlerActor extends BaseActor {
     map.put(JsonKey.TELEMETRY_EVENT_TYPE, "SEARCH");
     return map;
   }
-  public void lowerAndEncryptORFilterData(Map<String, Object> searchQueryMap) throws Exception {
+
+  /**
+   * this method will convert the  Sunbird required fields(source,externalId,userName,provider,loginId,email)
+   * into lower case and encrypt them ass well
+   * @param searchQueryMap
+   * @throws Exception
+   */
+  private void extractOrFilter(Map<String, Object> searchQueryMap) throws Exception {
     Map<String,Object>ORFilterMap= (Map<String, Object>) ((Map<String, Object>)(searchQueryMap.get(JsonKey.FILTERS))).get(JsonKey.ES_OR_OPERATION);
     if(MapUtils.isNotEmpty(ORFilterMap)) {
       Arrays.asList(

--- a/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
+++ b/actors/common/src/main/java/org/sunbird/learner/actors/search/SearchHandlerActor.java
@@ -348,7 +348,7 @@ public class SearchHandlerActor extends BaseActor {
 
   /**
    * this method will convert the  Sunbird required fields(source,externalId,userName,provider,loginId,email)
-   * into lower case and encrypt them as well
+   * into lower case and encrypt PI attributes well
    * @param searchQueryMap
    * @throws Exception
    */


### PR DESCRIPTION
<b>Ticket Ref: </b> [SC-1253](https://project-sunbird.atlassian.net/browse/SC-1253)
1: Search API support $or inside filter now
2: request body
>   {
    "request": {
        "filters": {
        "email":"test1@gmail.com",
        	"$or":{
        		"firstName":"xyx",
         		 "phone":"8318XXXXX"
        	}}}

3: Referred Document:[ DOC](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/query-dsl-bool-query.html)
4: In Search Handler Actor it will lower the values passed inside the $or in filters and encrypt them