### PR TITLE
SC-1266 Phone and Email Attribute Presence in Search AND Read APIs

### DIFF
--- a/actors/common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/actors/common/src/main/java/org/sunbird/learner/util/Util.java
@@ -1464,12 +1464,16 @@ public final class Util {
   }
 
   public static void addEmailAndPhone(Map<String, Object> userDetails) {
-    if (!StringUtils.isBlank((String) userDetails.get(JsonKey.ENC_PHONE))) {
-      userDetails.put(JsonKey.PHONE, userDetails.remove(JsonKey.ENC_PHONE));
-    }
-    if (!StringUtils.isBlank((String) userDetails.get(JsonKey.ENC_EMAIL))) {
-      userDetails.put(JsonKey.EMAIL, userDetails.remove(JsonKey.ENC_EMAIL));
-    }
+
+    userDetails.put(JsonKey.PHONE, userDetails.remove(JsonKey.ENC_PHONE));
+    userDetails.put(JsonKey.EMAIL, userDetails.remove(JsonKey.ENC_EMAIL));
+
+//
+//    if (!StringUtils.isBlank((String) userDetails.get(JsonKey.ENC_PHONE))) {
+//    }
+//    if (!StringUtils.isBlank((String) userDetails.get(JsonKey.ENC_EMAIL))) {
+//      userDetails.put(JsonKey.EMAIL, userDetails.remove(JsonKey.ENC_EMAIL));
+//    }
   }
 
   public static void checkProfileCompleteness(Map<String, Object> userMap) {
@@ -1568,12 +1572,12 @@ public final class Util {
   public static void addMaskEmailAndPhone(Map<String, Object> userMap) {
     String phone = (String) userMap.get(JsonKey.PHONE);
     String email = (String) userMap.get(JsonKey.EMAIL);
+    userMap.put(JsonKey.ENC_PHONE, phone);
+    userMap.put(JsonKey.ENC_EMAIL, email);
     if (!StringUtils.isBlank(phone)) {
-      userMap.put(JsonKey.ENC_PHONE, phone);
       userMap.put(JsonKey.PHONE, maskingService.maskPhone(decService.decryptData(phone)));
     }
     if (!StringUtils.isBlank(email)) {
-      userMap.put(JsonKey.ENC_EMAIL, email);
       userMap.put(JsonKey.EMAIL, maskingService.maskEmail(decService.decryptData(email)));
     }
   }

--- a/actors/common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/actors/common/src/main/java/org/sunbird/learner/util/Util.java
@@ -1454,6 +1454,7 @@ public final class Util {
       checkUserProfileVisibility(userDetails, actorRef);
       userDetails.remove(JsonKey.PASSWORD);
       addEmailAndPhone(userDetails);
+      checkEmailAndPhoneVerified(userDetails);
     } else {
       ProjectLogger.log(
           "Util:getUserProfile: User data not available to save in ES for userId : " + userId,
@@ -1464,16 +1465,17 @@ public final class Util {
   }
 
   public static void addEmailAndPhone(Map<String, Object> userDetails) {
-
     userDetails.put(JsonKey.PHONE, userDetails.remove(JsonKey.ENC_PHONE));
     userDetails.put(JsonKey.EMAIL, userDetails.remove(JsonKey.ENC_EMAIL));
+  }
+  public static void checkEmailAndPhoneVerified(Map<String, Object> userDetails){
+    if(StringUtils.isBlank((String)userDetails.get(JsonKey.EMAIL))){
+      userDetails.put(JsonKey.EMAIL_VERIFIED,false);
+    }
+    if(StringUtils.isBlank((String)userDetails.get(JsonKey.PHONE))){
+      userDetails.put(JsonKey.PHONE_VERIFIED,false);
+    }
 
-//
-//    if (!StringUtils.isBlank((String) userDetails.get(JsonKey.ENC_PHONE))) {
-//    }
-//    if (!StringUtils.isBlank((String) userDetails.get(JsonKey.ENC_EMAIL))) {
-//      userDetails.put(JsonKey.EMAIL, userDetails.remove(JsonKey.ENC_EMAIL));
-//    }
   }
 
   public static void checkProfileCompleteness(Map<String, Object> userMap) {


### PR DESCRIPTION
<b>Ticket Ref: </b>[SC-1266](https://project-sunbird.atlassian.net/browse/SC-1266)
1: If email is not passed while creating user, this email attribute will still come in user search, same with phone.
2: Check is been put if the user creates an account with email and still we are getting `phoneVerified: true` then we will make this property to false. same applicable to emailVerified.