### PR TITLE
Issue#SC-1293 added courseId and batchId in cert add request

### DIFF
--- a/actors/user/src/main/java/org/sunbird/user/actors/CertificateActor.java
+++ b/actors/user/src/main/java/org/sunbird/user/actors/CertificateActor.java
@@ -167,7 +167,6 @@ public class CertificateActor extends UserBaseActor {
     private void populateStoreMapWithUrlAndIds(Map<String, String> storeMap, Map<String, Object> certAddRequestMap) throws JsonProcessingException {
         storeMap.put(JsonKey.PDF_URL, (String) certAddRequestMap.get(JsonKey.PDF_URL));
         storeMap.put(JsonKey.JSON_DATA, objectMapper.writeValueAsString(certAddRequestMap.get(JsonKey.JSON_DATA)));
-        storeMap.put(JsonKey.BATCH_ID,(String)certAddRequestMap.get(JsonKey.BATCH_ID));
         String batchId=(String)certAddRequestMap.get(JsonKey.BATCH_ID);
         String courseId=(String)certAddRequestMap.get(JsonKey.COURSE_ID);
         storeMap.put(JsonKey.BATCH_ID, StringUtils.isNotBlank(batchId)?batchId:StringUtils.EMPTY);

--- a/actors/user/src/main/java/org/sunbird/user/actors/CertificateActor.java
+++ b/actors/user/src/main/java/org/sunbird/user/actors/CertificateActor.java
@@ -148,7 +148,7 @@ public class CertificateActor extends UserBaseActor {
         Map<String, String> storeMap = new HashMap<>();
         Map<String, Object> certAddReqMap = request.getRequest();
         assureUniqueCertId((String) certAddReqMap.get(JsonKey.ID));
-        populateStoreMapWithUrlAndIds(storeMap, certAddReqMap);
+        populateStoreData(storeMap, certAddReqMap);
         certAddReqMap.put(JsonKey.STORE, storeMap);
         certAddReqMap = getRequiredRequest(certAddReqMap);
         certAddReqMap.put(JsonKey.CREATED_AT, getTimeStamp());
@@ -164,7 +164,7 @@ public class CertificateActor extends UserBaseActor {
         sender().tell(response, self());
     }
 
-    private void populateStoreMapWithUrlAndIds(Map<String, String> storeMap, Map<String, Object> certAddRequestMap) throws JsonProcessingException {
+    private void populateStoreData(Map<String, String> storeMap, Map<String, Object> certAddRequestMap) throws JsonProcessingException {
         storeMap.put(JsonKey.PDF_URL, (String) certAddRequestMap.get(JsonKey.PDF_URL));
         storeMap.put(JsonKey.JSON_DATA, objectMapper.writeValueAsString(certAddRequestMap.get(JsonKey.JSON_DATA)));
         String batchId=(String)certAddRequestMap.get(JsonKey.BATCH_ID);


### PR DESCRIPTION
<b>Ticket Ref:</b> [SC-1293](https://project-sunbird.atlassian.net/browse/SC-1293)
1: courseId and batchId should come in the response to validating the certificate
2: while adding a certificate it should support two optional parameters courseId and batchId.
3: if courseId and batchId no validation is been performed 
4: if courseId and batchId is present we will save as it is value otherwise we will save blank string , since the null value in a map inside Cassandra is not supported yet.