### PR TITLE
SH-112 PU - User create API to take additional 'managedBy' param

### DIFF
--- a/actors/common/src/main/java/org/sunbird/learner/util/OTPUtil.java
+++ b/actors/common/src/main/java/org/sunbird/learner/util/OTPUtil.java
@@ -70,6 +70,8 @@ public final class OTPUtil {
     String sms = null;
     if (StringUtils.isBlank(template)) {
       sms = OTPService.getSmsBody(JsonKey.VERIFY_PHONE_OTP_TEMPLATE, smsTemplate);
+    } else if (StringUtils.isNotBlank(template) && StringUtils.equals(template, JsonKey.WARD_LOGIN_OTP_TEMPLATE_ID)) {
+      sms = OTPService.getSmsBody(JsonKey.OTP_PHONE_WARD_LOGIN_TEMPLATE, smsTemplate);
     } else {
       sms = OTPService.getSmsBody(JsonKey.OTP_PHONE_RESET_PASSWORD_TEMPLATE, smsTemplate);
     }
@@ -146,6 +148,8 @@ public final class OTPUtil {
     emailTemplateMap.put(JsonKey.RECIPIENT_EMAILS, reciptientsMail);
     if (StringUtils.isBlank((String) emailTemplateMap.get(JsonKey.TEMPLATE_ID))) {
       emailTemplateMap.put(JsonKey.EMAIL_TEMPLATE_TYPE, JsonKey.OTP);
+    } else if (StringUtils.isNotBlank((String) emailTemplateMap.get(JsonKey.TEMPLATE_ID)) && StringUtils.equals((String) emailTemplateMap.get(JsonKey.TEMPLATE_ID), JsonKey.WARD_LOGIN_OTP_TEMPLATE_ID)) {
+      emailTemplateMap.put(JsonKey.EMAIL_TEMPLATE_TYPE, JsonKey.OTP_EMAIL_WARD_LOGIN_TEMPLATE);
     } else {
       // send otp to email while reseting password from portal
       emailTemplateMap.put(JsonKey.EMAIL_TEMPLATE_TYPE, JsonKey.OTP_EMAIL_RESET_PASSWORD_TEMPLATE);

--- a/actors/common/src/main/java/org/sunbird/models/user/User.java
+++ b/actors/common/src/main/java/org/sunbird/models/user/User.java
@@ -69,6 +69,8 @@ public class User implements Serializable {
   private int flagsValue;
   private String recoveryEmail;
   private String recoveryPhone;
+  private String managedBy;
+  private String accessCode;
 
   public List<String> getLocationIds() {
     return locationIds;
@@ -471,4 +473,11 @@ public class User implements Serializable {
     this.recoveryPhone = recoveryPhone;
   }
 
+  public String getManagedBy() { return managedBy; }
+
+  public void setManagedBy(String managedBy) { this.managedBy = managedBy; }
+
+  public String getAccessCode() { return accessCode; }
+
+  public void setAccessCode(String accessCode) { this.accessCode = accessCode; }
 }

--- a/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -830,6 +830,7 @@ public class UserManagementActor extends BaseActor {
     } else {
       ProjectLogger.log("UserManagementActor:processUserRequest: User creation failure");
     }
+
     // Enable this when you want to send full response of user attributes
     Map<String, Object> esResponse = new HashMap<>();
     esResponse.putAll((Map<String, Object>) resp.getResult().get(JsonKey.RESPONSE));

--- a/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -28,6 +28,7 @@ import org.sunbird.actorutil.org.impl.OrganisationClientImpl;
 import org.sunbird.actorutil.systemsettings.SystemSettingClient;
 import org.sunbird.actorutil.systemsettings.impl.SystemSettingClientImpl;
 import org.sunbird.cassandra.CassandraOperation;
+import org.sunbird.common.ElasticSearchHelper;
 import org.sunbird.common.exception.ProjectCommonException;
 import org.sunbird.common.factory.EsClientFactory;
 import org.sunbird.common.inf.ElasticSearchService;
@@ -484,6 +485,14 @@ public class UserManagementActor extends BaseActor {
         return;
       }
     }
+    String managedBy = (String) userMap.get(JsonKey.MANAGED_BY);
+    if (StringUtils.isNotEmpty(managedBy)) {
+      String channel = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_CHANNEL);
+      String rootOrgId = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_ID);
+      userMap.put(JsonKey.ROOT_ORG_ID, rootOrgId);
+      userMap.put(JsonKey.CHANNEL, channel);
+      isCustodianOrg = true;
+    }
     validateUserType(userMap, isCustodianOrg);
     if (userMap.containsKey(JsonKey.ORG_EXTERNAL_ID)) {
       String orgExternalId = (String) userMap.get(JsonKey.ORG_EXTERNAL_ID);
@@ -603,8 +612,18 @@ public class UserManagementActor extends BaseActor {
   private void processUserRequestV3(Map<String, Object> userMap, String signupType, String source) {
     UserUtil.setUserDefaultValueForV3(userMap);
     UserUtil.toLower(userMap);
-    UserUtil.checkPhoneUniqueness((String) userMap.get(JsonKey.PHONE));
-    UserUtil.checkEmailUniqueness((String) userMap.get(JsonKey.EMAIL));
+
+    String managedBy = (String) userMap.get(JsonKey.MANAGED_BY);
+    if (StringUtils.isEmpty(managedBy)) {
+      UserUtil.checkPhoneUniqueness((String) userMap.get(JsonKey.PHONE));
+      UserUtil.checkEmailUniqueness((String) userMap.get(JsonKey.EMAIL));
+    }else{
+      String channel = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_CHANNEL);
+      String rootOrgId = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_ID);
+      userMap.put(JsonKey.ROOT_ORG_ID, rootOrgId);
+      userMap.put(JsonKey.CHANNEL, channel);
+      Map<String, Object> managedByInfo = UserUtil.validateManagedByUser(managedBy);
+    }
     String userId = ProjectUtil.generateUniqueId();
     userMap.put(JsonKey.ID, userId);
     userMap.put(JsonKey.USER_ID, userId);
@@ -617,19 +636,20 @@ public class UserManagementActor extends BaseActor {
     userMap.put(JsonKey.IS_DELETED, false);
     Map<String, Boolean> userFlagsMap = new HashMap<>();
     userFlagsMap.put(JsonKey.STATE_VALIDATED, false);
-
-    userFlagsMap.put(
-        JsonKey.EMAIL_VERIFIED,
-        (Boolean)
-            (userMap.get(JsonKey.EMAIL_VERIFIED) != null
-                ? userMap.get(JsonKey.EMAIL_VERIFIED)
-                : false));
-    userFlagsMap.put(
-        JsonKey.PHONE_VERIFIED,
-        (Boolean)
-            (userMap.get(JsonKey.PHONE_VERIFIED) != null
-                ? userMap.get(JsonKey.PHONE_VERIFIED)
-                : false));
+    if (StringUtils.isEmpty(managedBy)) {
+      userFlagsMap.put(
+              JsonKey.EMAIL_VERIFIED,
+              (Boolean)
+                      (userMap.get(JsonKey.EMAIL_VERIFIED) != null
+                              ? userMap.get(JsonKey.EMAIL_VERIFIED)
+                              : false));
+      userFlagsMap.put(
+              JsonKey.PHONE_VERIFIED,
+              (Boolean)
+                      (userMap.get(JsonKey.PHONE_VERIFIED) != null
+                              ? userMap.get(JsonKey.PHONE_VERIFIED)
+                              : false));
+    }
     int userFlagValue = userFlagsToNum(userFlagsMap);
     userMap.put(JsonKey.FLAGS_VALUE, userFlagValue);
     final String password = (String) userMap.get(JsonKey.PASSWORD);
@@ -758,6 +778,16 @@ public class UserManagementActor extends BaseActor {
     UserUtil.validateUserPhoneEmailAndWebPages(user, JsonKey.CREATE);
     convertValidatedLocationCodesToIDs(userMap);
 
+    String managedBy = (String) userMap.get(JsonKey.MANAGED_BY);
+    String managedByEmail = null;
+    String managedByPhone = null;
+    if (StringUtils.isNotEmpty(managedBy)) {
+      Map<String, Object> managedByInfo = UserUtil.validateManagedByUser(managedBy);
+
+      managedByEmail = (String) managedByInfo.get(JsonKey.EMAIL);
+      managedByPhone = (String) managedByInfo.get(JsonKey.PHONE);
+    }
+
     UserUtil.toLower(userMap);
     String userId = ProjectUtil.generateUniqueId();
     userMap.put(JsonKey.ID, userId);
@@ -831,6 +861,10 @@ public class UserManagementActor extends BaseActor {
     }
     requestMap.put(JsonKey.PASSWORD, userMap.get(JsonKey.PASSWORD));
     if (StringUtils.isNotBlank(callerId)) {
+      if (StringUtils.isNotEmpty(managedBy)) {
+        requestMap.put(JsonKey.EMAIL, managedByEmail);
+        requestMap.put(JsonKey.PHONE, managedByPhone);
+      }
       sendEmailAndSms(requestMap);
     }
     Map<String, Object> targetObject = null;

--- a/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -617,7 +617,7 @@ public class UserManagementActor extends BaseActor {
     if (StringUtils.isEmpty(managedBy)) {
       UserUtil.checkPhoneUniqueness((String) userMap.get(JsonKey.PHONE));
       UserUtil.checkEmailUniqueness((String) userMap.get(JsonKey.EMAIL));
-    }else{
+    } else{
       String channel = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_CHANNEL);
       String rootOrgId = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_ID);
       userMap.put(JsonKey.ROOT_ORG_ID, rootOrgId);
@@ -784,8 +784,8 @@ public class UserManagementActor extends BaseActor {
     if (StringUtils.isNotEmpty(managedBy)) {
       Map<String, Object> managedByInfo = UserUtil.validateManagedByUser(managedBy);
 
-      managedByEmail = (String) managedByInfo.get(JsonKey.EMAIL);
-      managedByPhone = (String) managedByInfo.get(JsonKey.PHONE);
+      managedByEmail = (String) managedByInfo.get(JsonKey.ENC_EMAIL);
+      managedByPhone = (String) managedByInfo.get(JsonKey.ENC_PHONE);
     }
 
     UserUtil.toLower(userMap);

--- a/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -760,6 +760,23 @@ public class UserUtil {
               }
             });
   }
+
+  public static Map<String, Object> validateManagedByUser(String managedBy) {
+    Future<Map<String, Object>> managedByInfoF =
+            esUtil.getDataByIdentifier(ProjectUtil.EsType.user.getTypeName(), managedBy);
+    Map<String, Object> managedByInfo = (Map<String, Object>) ElasticSearchHelper.getResponseFromFuture(managedByInfoF);
+    if (ProjectUtil.isNull(managedByInfo)
+            || StringUtils.isBlank((String) managedByInfo.get(JsonKey.FIRST_NAME))
+            || StringUtils.isNotBlank((String) managedByInfo.get(JsonKey.MANAGED_BY))
+            || (null != managedByInfo.get(JsonKey.IS_DELETED) && (boolean) (managedByInfo.get(JsonKey.IS_DELETED))) ) {
+      throw new ProjectCommonException(
+              ResponseCode.invalidRequestData.getErrorCode(),
+              ResponseCode.invalidRequestData.getErrorMessage(),
+              ResponseCode.CLIENT_ERROR.getResponseCode());
+    }
+    UserUtility.decryptUserDataFrmES(managedByInfo);
+    return managedByInfo;
+  }
 }
 
 @FunctionalInterface


### PR DESCRIPTION
User create API to take additional 'managedBy' param

- “managedBy” should be UUID of a valid user and this user should have “managedBy” value as null
- rootOrg of the managed user (i.e. when managedBy is non-null) should be the custodian org