### PR TITLE
Issue #SH-135 managedby-user::update scenario - when email/phone is u…

### DIFF
--- a/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -207,7 +207,7 @@ public class UserManagementActor extends BaseActor {
     Map<String, Boolean> userBooleanMap = updatedUserFlagsMap(userMap, userDbRecord);
     int userFlagValue = userFlagsToNum(userBooleanMap);
     requestMap.put(JsonKey.FLAGS_VALUE, userFlagValue);
-    if (StringUtils.isNotEmpty((String) requestMap.get(JsonKey.MANAGED_BY))
+    if (StringUtils.isNotEmpty((String) userDbRecord.get(JsonKey.MANAGED_BY))
             && (StringUtils.isNotEmpty((String) requestMap.get(JsonKey.EMAIL)))
         || (StringUtils.isNotEmpty((String) requestMap.get(JsonKey.PHONE)))) {
       requestMap.put(JsonKey.MANAGED_BY, null);
@@ -915,6 +915,15 @@ public class UserManagementActor extends BaseActor {
     } else {
       userBooleanMap.put(
           JsonKey.STATE_VALIDATED, (boolean) userDbRecord.get(JsonKey.STATE_VALIDATED));
+    }
+    // adding in release-3.0.0
+    // checks if user is managedBy other user and updates emailverified and phoneverified value
+    if (StringUtils.isNotEmpty((String) userDbRecord.get(JsonKey.MANAGED_BY))) {
+      if (userMap.containsKey("JsonKey.EMAIL")) {
+        emailVerified = true;
+      } else if (userMap.containsKey("JsonKey.PHONE")) {
+        phoneVerified = true;
+      }
     }
     userBooleanMap.put(JsonKey.EMAIL_VERIFIED, emailVerified);
     userBooleanMap.put(JsonKey.PHONE_VERIFIED, phoneVerified);

--- a/actors/user/src/main/java/org/sunbird/user/service/UserService.java
+++ b/actors/user/src/main/java/org/sunbird/user/service/UserService.java
@@ -12,7 +12,7 @@ public interface UserService {
 
   User getUserById(String userId);
 
-  void validateUserId(Request request);
+  void validateUserId(Request request, String managedById);
 
   void validateUploader(Request request);
 

--- a/actors/user/src/main/java/org/sunbird/user/service/impl/UserServiceImpl.java
+++ b/actors/user/src/main/java/org/sunbird/user/service/impl/UserServiceImpl.java
@@ -98,11 +98,12 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public void validateUserId(Request request) {
+  public void validateUserId(Request request, String managedById) {
     String ctxtUserId = (String) request.getContext().get(JsonKey.USER_ID);
     String userId = userExtIdentityDao.getUserId(request);
 
-    if ((!StringUtils.isBlank(userId)) && (!userId.equals(ctxtUserId))) {
+    if (((!StringUtils.isBlank(userId)) && !userId.equals(ctxtUserId))
+        || (StringUtils.isNotEmpty(managedById) && ctxtUserId.equals(managedById))) {
       throw new ProjectCommonException(
           ResponseCode.unAuthorized.getErrorCode(),
           ResponseCode.unAuthorized.getErrorMessage(),
@@ -265,11 +266,11 @@ public class UserServiceImpl implements UserService {
         if (StringUtils.isBlank(channel)) {
           SystemSettingClient client = SystemSettingClientImpl.getInstance();
           SystemSetting custodianOrgChannelSetting =
-                  client.getSystemSettingByField(
-                          actorRef,
-                          JsonKey.CUSTODIAN_ORG_CHANNEL);
-          if (custodianOrgChannelSetting != null &&  StringUtils.isNotBlank(custodianOrgChannelSetting.getValue())) {
-            configSettingMap.put(custodianOrgChannelSetting.getId(), custodianOrgChannelSetting.getValue());
+              client.getSystemSettingByField(actorRef, JsonKey.CUSTODIAN_ORG_CHANNEL);
+          if (custodianOrgChannelSetting != null
+              && StringUtils.isNotBlank(custodianOrgChannelSetting.getValue())) {
+            configSettingMap.put(
+                custodianOrgChannelSetting.getId(), custodianOrgChannelSetting.getValue());
             channel = custodianOrgChannelSetting.getValue();
           }
         }


### PR DESCRIPTION
…pdated, managedBy flag set to null

when email/phone is updated for a managedBy user, then managedBy filed is set to null.
Response:
`{
    "id": "api.user.update",
    "ver": "v1",
    "ts": "2020-05-19 12:07:34:772+0530",
    "params": {
        "resmsgid": null,
        "msgid": null,
        "err": null,
        "status": "success",
        "errmsg": null
    },
    "responseCode": "OK",
    "result": {
        "response": "SUCCESS",
        "link": "reset_password_link.html"
    }
}`